### PR TITLE
Add basic visual novel engine

### DIFF
--- a/game.py
+++ b/game.py
@@ -1,0 +1,24 @@
+import os
+
+HEALTH_MAX = 100
+
+def draw_bar(label, value, max_value, length=20):
+    filled = int(length * value / max_value)
+    empty = length - filled
+    bar = '█' * filled + ' ' * empty
+    return f"{label}: [{bar}] {value}/{max_value}"
+
+def display_scene(scene_path, health, location, clear=True):
+    if clear:
+        os.system('clear')
+    print(draw_bar('Health', health, HEALTH_MAX))
+    print(f"Location: {location}")
+    print('=' * 40)
+    with open(scene_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            print(line.rstrip('\n'))
+
+if __name__ == '__main__':
+    health = 80
+    location = 'Dreamscape'
+    display_scene('scenes/prologue.txt', health, location)

--- a/scenes/prologue.txt
+++ b/scenes/prologue.txt
@@ -1,0 +1,16 @@
+###############################################
+#                                             #
+#                .-""-._                     #
+#              /        \                    #
+#             |  ()  ()  |                   #
+#              \  ____  /                    #
+#               `------'                     #
+#                                             #
+###############################################
+
+[NARRATOR]
+A repeated clang of metal rings in your ears.
+A bright glint of steel burns in your eyes.
+
+[INNER THOUGHTS]
+"He must have long forgotten any human fear..."


### PR DESCRIPTION
## Summary
- add simple Python script to display scenes with health and location gauges
- include sample `prologue.txt` scene demonstrating 8-bit style ASCII art

## Testing
- `python3 - <<'PY'
from game import display_scene

display_scene('scenes/prologue.txt', 80, 'Dreamscape', clear=False)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6850cad72e2c8326a999f4dba0164840